### PR TITLE
Only include actual source from Podspec

### DIFF
--- a/ACEView.podspec
+++ b/ACEView.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.platform     = :osx
   s.frameworks   = ['WebKit']
   s.resource     = ['ACEView/Dependencies/ace/src/*.js', 'ACEView/HTML/index.html']
-  s.source_files = 'ACEView/**/*.{h,m}'
+  s.source_files = 'ACEView/Source/**/*.{h,m}'
 end


### PR DESCRIPTION
The previous glob caused a demo file from Ace to be included in the
build.

ACEView/Dependencies/ace/demo/kitchen-sink/docs/objectivec.m
