### PR TITLE
Add initWithCoder and refactor common code into initWebView

### DIFF
--- a/ACEView/Source/ACEView.m
+++ b/ACEView/Source/ACEView.m
@@ -26,6 +26,8 @@ static NSArray *allowedSelectorNamesForJavaScript;
 
 @interface ACEView()
 
+- (void) initWebView;
+
 - (NSString *) aceJavascriptDirectoryPath;
 - (NSString *) htmlPageFilePath;
 
@@ -50,15 +52,26 @@ static NSArray *allowedSelectorNamesForJavaScript;
 @synthesize firstSelectedRange, delegate;
 
 #pragma mark - Internal
-- (id) initWithFrame:(NSRect)frame {
-    self = [super initWithFrame:frame];
-    if (self == nil) {
-        return nil;
-    }
 
+- (void) initWebView
+{
     webView = [[WebView alloc] init];
     [webView setFrameLoadDelegate:self];
+}
+
+- (id) initWithFrame:(NSRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        [self initWebView];
+    }
     
+    return self;
+}
+
+- (id) initWithCoder:(NSCoder *)coder {
+    if ((self = [super initWithCoder:coder])) {
+        [self initWebView];
+    }
+
     return self;
 }
 


### PR DESCRIPTION
In newer versions of Xcode, if the "Instantiation: Prefer coder" check box is ticked for a .nib or .xib files, custom view instances get initialized with initWithCoder: instead of initWithFrame:, which in the case of ACEView causes silent failure, as the web view is not initialized.

This pull request adds an initWithCoder: method and factors out the common webView initialization code into a separate method.