### PR TITLE
disables ARC in podfile

### DIFF
--- a/ACEView.podspec
+++ b/ACEView.podspec
@@ -20,4 +20,5 @@ Pod::Spec.new do |s|
   s.frameworks   = ['WebKit']
   s.resource     = ['ACEView/Dependencies/ace/src/*.js', 'ACEView/HTML/index.html']
   s.source_files = 'ACEView/Source/**/*.{h,m}'
+  s.requires_arc = false
 end


### PR DESCRIPTION
I think the podspec needs to disable ARC explicitly, because it's on by default