### PR TITLE
ACEWebView.h is an implementation detail that clients don't need to know...

### DIFF
--- a/ACEView/Source/ACEView.m
+++ b/ACEView/Source/ACEView.m
@@ -15,6 +15,7 @@
 
 #import <ACEView/NSString+EscapeForJavaScript.h>
 #import <ACEView/NSInvocation+MainThread.h>
+#import "ACEWebView.h"
 
 #define ACE_JAVASCRIPT_DIRECTORY @"___ACE_VIEW_JAVASCRIPT_DIRECTORY___"
 

--- a/ACEView/Source/Headers/ACEView.h
+++ b/ACEView/Source/Headers/ACEView.h
@@ -11,7 +11,6 @@
 #import <ACEView/ACEModes.h>
 #import <ACEView/ACEThemes.h>
 #import <ACEView/ACEKeyboardHandlers.h>
-#import "ACEWebView.h"
 
 extern NSString *const ACETextDidEndEditingNotification;
 
@@ -33,7 +32,7 @@ extern NSString *const ACETextDidEndEditingNotification;
 @interface ACEView : NSScrollView <NSTextFinderClient> {
     NSTextFinder *textFinder;
     CGColorRef _borderColor;
-	ACEWebView *webView;
+	WebView *webView;
 
     id delegate;
 


### PR DESCRIPTION
The include of "ACEWebView.h" in "ACEView.h" causes search path problems in existing clients. Furthermore, `ACEWebView` is an implementation detail; all the functionality is provided by the class itself, and none by APIs called by `ACEView`. This pull request stores the `ACEWebView` as a `WebView` and avoids these problems.