### PR TITLE
Printing revisited: Headers & Footers, bug fixes

### DIFF
--- a/ACE View Example/ACEViewAppDelegate.m
+++ b/ACE View Example/ACEViewAppDelegate.m
@@ -64,9 +64,9 @@
     NSLog(@"%s", __PRETTY_FUNCTION__);
 }
 
-- (NSString *)printJobTitle
+- (void)startPrintOperation:(NSPrintOperation *)printOp
 {
-    return @"ACE View Print";
+    printOp.jobTitle = @"ACE View Print";
 }
 
 - (float) printHeaderHeight

--- a/ACE View Example/ACEViewAppDelegate.m
+++ b/ACE View Example/ACEViewAppDelegate.m
@@ -64,6 +64,11 @@
     NSLog(@"%s", __PRETTY_FUNCTION__);
 }
 
+- (NSString *)printJobTitle
+{
+    return @"ACE View Print";
+}
+
 - (float) printHeaderHeight
 {
     return 20.0f;

--- a/ACE View Example/ACEViewAppDelegate.m
+++ b/ACE View Example/ACEViewAppDelegate.m
@@ -57,9 +57,56 @@
     [aceView setKeyboardHandler:[keyboardHandler indexOfSelectedItem]];
 }
 
+#pragma mark - Delegate methods
+
 - (void) textDidChange:(NSNotification *)notification {
     // Handle text changes
     NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
+- (float) printHeaderHeight
+{
+    return 20.0f;
+}
+
+- (float) printFooterHeight
+{
+    return 12.0f;
+}
+
+//
+// I'm not saying that this flashy look goes best with the content
+// of the page, this is just to demonstrate the possibilities.
+//
+- (void) drawPrintHeaderForPage:(int)pageNo inRect:(NSRect)rect
+{
+    NSGradient * gradient =
+        [[NSGradient alloc] initWithStartingColor:[NSColor colorWithWhite:0.3 alpha:1.0]
+                                      endingColor:[NSColor colorWithWhite:0.95 alpha:1.0]];
+    [gradient drawInRect:rect angle:0.0];
+    NSString *      pageString  = [NSString stringWithFormat:@"%d", pageNo];
+    NSFont *        pageFont    = [NSFont userFixedPitchFontOfSize: 15.0];
+    NSDictionary *  attr        = @{NSFontAttributeName: pageFont};
+
+    NSSize size     = [pageString sizeWithAttributes:attr];
+    size.width     += 10.0;
+    rect.origin.x  += rect.size.width-size.width;
+    rect.size.width = size.width;
+    rect.origin.y  += 0.5*(rect.size.height-pageFont.ascender);
+    [pageString drawInRect:rect withAttributes:attr];
+}
+
+- (void) drawPrintFooterForPage:(int)pageNo inRect:(NSRect)rect
+{
+    NSString *      colophon    = @"Printed by ACE View Example";
+    NSFont *        coloFont    = [NSFont userFontOfSize:9.0];
+    NSDictionary *  attr        = @{NSFontAttributeName: coloFont};
+
+    NSSize  size    = [colophon sizeWithAttributes:attr];
+    NSPoint at      = {
+        rect.origin.x+0.5*(rect.size.width-size.width),
+        rect.origin.y-coloFont.descender};
+    [colophon drawAtPoint:at withAttributes:attr];
 }
 
 @end

--- a/ACEView/Source/ACEView.m
+++ b/ACEView/Source/ACEView.m
@@ -374,7 +374,7 @@ static NSArray *allowedSelectorNamesForJavaScript;
         @"ace.require(\"ace/config\").loadModule(\"ace/ext/static_highlight\", function(static) {"
             "var session = editor.getSession();"
             "var printable = static.renderSync(session.getValue(), session.getMode(), editor.renderer.theme);"
-            "var css = \"<style>span {font-size: %dpx;}\" + printable.css + \"</style>\";"
+            "var css = \"<style>body {white-space:pre-wrap;} span {font-size: %dpx;}\" + printable.css + \"</style>\";"
             "var doc = css + printable.html;"
             "ACEView.printHTML_(doc);"
         "});", printFontSize];
@@ -397,10 +397,9 @@ static NSArray *allowedSelectorNamesForJavaScript;
     //
     // Compute width
     //
-    const float kExtraMargin = 30.0f;
     NSRect frame = printingView.frame;
     frame.size.height = 1;
-    frame.size.width  = printInfo.paperSize.width-printInfo.leftMargin-printInfo.rightMargin-kExtraMargin;
+    frame.size.width  = printInfo.paperSize.width-printInfo.leftMargin-printInfo.rightMargin;
     printingView.frame = frame;
 
     //
@@ -408,8 +407,6 @@ static NSArray *allowedSelectorNamesForJavaScript;
     // pre-wrap property instead.
     //
     html = [html stringByReplacingOccurrencesOfString:@"\u00A0" withString:@" "];
-    html = [NSString stringWithFormat:@"<div style=\"width: %.1fpx;white-space:pre-wrap;\">%@</div>",
-            frame.size.width, html];
     [printingView.mainFrame loadHTMLString:html baseURL:nil];
 
     void (^__block print)(void) = ^{

--- a/ACEView/Source/ACEView.m
+++ b/ACEView/Source/ACEView.m
@@ -423,6 +423,11 @@ static NSArray *allowedSelectorNamesForJavaScript;
 
             NSView * viewToPrint = [[[printingView mainFrame] frameView] documentView];
             printOperation = [NSPrintOperation printOperationWithView:viewToPrint printInfo:printInfo];
+            if ([delegate respondsToSelector:@selector(printJobTitle)])
+                printOperation.jobTitle = [delegate printJobTitle];
+            else
+                printOperation.jobTitle = [self printJobTitle];
+
             [printOperation runOperation];
             printOperation = nil;
         }

--- a/ACEView/Source/ACEView.m
+++ b/ACEView/Source/ACEView.m
@@ -387,8 +387,8 @@ static NSArray *allowedSelectorNamesForJavaScript;
     // Obtain print info and customize it
     //
     NSPrintInfo * printInfo = nil;
-    if ([delegate respondsToSelector:@selector(printSettings)])
-        printInfo = [delegate printSettings];
+    if ([delegate respondsToSelector:@selector(printInformation)])
+        printInfo = [delegate printInformation];
     if (!printInfo)
         printInfo = [NSPrintInfo sharedPrintInfo];
     printInfo = [printInfo copy];
@@ -423,11 +423,10 @@ static NSArray *allowedSelectorNamesForJavaScript;
 
             NSView * viewToPrint = [[[printingView mainFrame] frameView] documentView];
             printOperation = [NSPrintOperation printOperationWithView:viewToPrint printInfo:printInfo];
-            if ([delegate respondsToSelector:@selector(printJobTitle)])
-                printOperation.jobTitle = [delegate printJobTitle];
-            else
-                printOperation.jobTitle = [self printJobTitle];
- 
+            printOperation.jobTitle = [self printJobTitle];
+
+            if ([delegate respondsToSelector:@selector(startPrintOperation:)])
+                [delegate startPrintOperation:printOperation];
             [printOperation runOperationModalForWindow:[self window] delegate:self didRunSelector:@selector(finishedPrinting:) contextInfo:NULL];
         }
     };
@@ -437,8 +436,8 @@ static NSArray *allowedSelectorNamesForJavaScript;
 - (void)finishedPrinting:(void *)context
 {
     printOperation = nil;
-    if ([delegate respondsToSelector:@selector(printingComplete)])
-        [delegate printingComplete];
+    if ([delegate respondsToSelector:@selector(endPrintOperation)])
+        [delegate endPrintOperation];
 }
 
 @end

--- a/ACEView/Source/ACEView.m
+++ b/ACEView/Source/ACEView.m
@@ -374,8 +374,8 @@ static NSArray *allowedSelectorNamesForJavaScript;
         @"ace.require(\"ace/config\").loadModule(\"ace/ext/static_highlight\", function(static) {"
             "var session = editor.getSession();"
             "var printable = static.renderSync(session.getValue(), session.getMode(), editor.renderer.theme);"
-            "var css = \"<style>body {white-space:pre-wrap;} span {font-size: %dpx;}\" + printable.css + \"</style>\";"
-            "var doc = css + printable.html;"
+            "var css = \"<style>body {white-space:pre-wrap;}\" + printable.css + \"</style>\";"
+            "var doc = css.replace(/(font-size:)\\s*\\d+(px)/g, '$1 %d$2') + printable.html;"
             "ACEView.printHTML_(doc);"
         "});", printFontSize];
     [self executeScriptWhenLoaded: staticRender];

--- a/ACEView/Source/ACEView.m
+++ b/ACEView/Source/ACEView.m
@@ -387,8 +387,8 @@ static NSArray *allowedSelectorNamesForJavaScript;
     // Obtain print info and customize it
     //
     NSPrintInfo * printInfo = nil;
-    if ([delegate respondsToSelector:@selector(printInfo)])
-        printInfo = [delegate printInfo];
+    if ([delegate respondsToSelector:@selector(printSettings)])
+        printInfo = [delegate printSettings];
     if (!printInfo)
         printInfo = [NSPrintInfo sharedPrintInfo];
     printInfo = [printInfo copy];
@@ -437,6 +437,8 @@ static NSArray *allowedSelectorNamesForJavaScript;
 - (void)finishedPrinting:(void *)context
 {
     printOperation = nil;
+    if ([delegate respondsToSelector:@selector(printingComplete)])
+        [delegate printingComplete];
 }
 
 @end

--- a/ACEView/Source/ACEView.m
+++ b/ACEView/Source/ACEView.m
@@ -427,12 +427,16 @@ static NSArray *allowedSelectorNamesForJavaScript;
                 printOperation.jobTitle = [delegate printJobTitle];
             else
                 printOperation.jobTitle = [self printJobTitle];
-
-            [printOperation runOperation];
-            printOperation = nil;
+ 
+            [printOperation runOperationModalForWindow:[self window] delegate:self didRunSelector:@selector(finishedPrinting:) contextInfo:NULL];
         }
     };
     print();
+}
+
+- (void)finishedPrinting:(void *)context
+{
+    printOperation = nil;
 }
 
 @end

--- a/ACEView/Source/Headers/ACEView.h
+++ b/ACEView/Source/Headers/ACEView.h
@@ -27,8 +27,8 @@ extern NSString *const ACETextDidEndEditingNotification;
 /** Provides a title for the print job. Defaults to the view's printJobTitle */
 @optional - (NSString *)printJobTitle;
 
-/** Provides the print settings to be used for a print job. Defaults to application shared settings. */
-@optional - (NSPrintInfo *)printInfo;
+/** Provides the print settings to be used for a print job. Defaults to application shared settings.*/
+@optional - (NSPrintInfo *)printSettings;
 
 /** Provides the desired font size for printing. Defaults to 10px */
 @optional - (int)printFontSize;
@@ -40,6 +40,9 @@ extern NSString *const ACETextDidEndEditingNotification;
 /** Draws the headers and footers. Defaults to no headers and footers */
 @optional - (void)drawPrintHeaderForPage:(int)pageNo inRect:(NSRect)rect;
 @optional - (void)drawPrintFooterForPage:(int)pageNo inRect:(NSRect)rect;
+
+/** Ends a print job */
+@optional - (void)printingComplete;
 
 @end
 

--- a/ACEView/Source/Headers/ACEView.h
+++ b/ACEView/Source/Headers/ACEView.h
@@ -30,6 +30,14 @@ extern NSString *const ACETextDidEndEditingNotification;
 /** Provides the desired font size for printing. Defaults to 10px */
 @optional - (int)printFontSize;
 
+/** Provides the desired height for page headers and footers. Defaults to 0.0px */
+@optional - (float)printHeaderHeight;
+@optional - (float)printFooterHeight;
+
+/** Draws the headers and footers. Defaults to no headers and footers */
+@optional - (void)drawPrintHeaderForPage:(int)pageNo inRect:(NSRect)rect;
+@optional - (void)drawPrintFooterForPage:(int)pageNo inRect:(NSRect)rect;
+
 @end
 
 /** This class provides the main public interface for the ACEView. */

--- a/ACEView/Source/Headers/ACEView.h
+++ b/ACEView/Source/Headers/ACEView.h
@@ -24,11 +24,8 @@ extern NSString *const ACETextDidEndEditingNotification;
  */
 @optional - (void) textDidChange:(NSNotification *)notification;
 
-/** Provides a title for the print job. Defaults to the view's printJobTitle */
-@optional - (NSString *)printJobTitle;
-
 /** Provides the print settings to be used for a print job. Defaults to application shared settings.*/
-@optional - (NSPrintInfo *)printSettings;
+@optional - (NSPrintInfo *)printInformation;
 
 /** Provides the desired font size for printing. Defaults to 10px */
 @optional - (int)printFontSize;
@@ -41,8 +38,9 @@ extern NSString *const ACETextDidEndEditingNotification;
 @optional - (void)drawPrintHeaderForPage:(int)pageNo inRect:(NSRect)rect;
 @optional - (void)drawPrintFooterForPage:(int)pageNo inRect:(NSRect)rect;
 
-/** Ends a print job */
-@optional - (void)printingComplete;
+/** Called before starting and ending a print job */
+@optional - (void)startPrintOperation:(NSPrintOperation *)printOp;
+@optional - (void)endPrintOperation;
 
 @end
 

--- a/ACEView/Source/Headers/ACEView.h
+++ b/ACEView/Source/Headers/ACEView.h
@@ -22,7 +22,7 @@ extern NSString *const ACETextDidEndEditingNotification;
 
  @param notification The ACETextDidEndEditingNotification notification that is posted to the default notification center.
  */
-- (void) textDidChange:(NSNotification *)notification;
+@optional - (void) textDidChange:(NSNotification *)notification;
 
 /** Provides a title for the print job. Defaults to the view's printJobTitle */
 @optional - (NSString *)printJobTitle;

--- a/ACEView/Source/Headers/ACEView.h
+++ b/ACEView/Source/Headers/ACEView.h
@@ -24,6 +24,9 @@ extern NSString *const ACETextDidEndEditingNotification;
  */
 - (void) textDidChange:(NSNotification *)notification;
 
+/** Provides a title for the print job. Defaults to the view's printJobTitle */
+@optional - (NSString *)printJobTitle;
+
 /** Provides the print settings to be used for a print job. Defaults to application shared settings. */
 @optional - (NSPrintInfo *)printInfo;
 


### PR DESCRIPTION
This adds support for headers and footers, as well as fixing a number of bugs in the original printing implementation. 

Changes to existing functionality:
 * Made the `textDidChange:` delegate method optional as well (because it's perfectly possible to only be
   interested in some of the other delegate methods).
 * Renamed `printInfo` to `printInformation` (because there is an existing `printInfo` attribute in `NSDocument`, and if an `NSDocument` subclass is set as the `ACEView` delegate, that makes it difficult to override, e.g. for customizing the print information before passing it to the `ACEView` print job).
 * Added somewhat tacky headers and footers to the printing in `ACE View Example` to demonstrate the possibilities.

Bugs fixed:
 * The width of the print area was being artificially restricted.
 * The font size was being adjusted in a way that did not correspondingly adjust line heights, with ugly results.
 * The print dialog now is being shown as a modal sheet. 