### PR TITLE
Adopt Objective C Lightweight Generics

### DIFF
--- a/ACEView/Source/Utilities/Headers/ACEKeyboardHandlerNames.h
+++ b/ACEView/Source/Utilities/Headers/ACEKeyboardHandlerNames.h
@@ -17,12 +17,12 @@
 
  @return Array of ACE keyboard handler names.
  */
-+ (NSArray *) keyboardHandlerCommands;
++ (NSArray<NSString *> *) keyboardHandlerCommands;
 /** Return an array of human-readable ACE keyboard handler names.
 
  @return Array of human-readable ACE keyboard handler names.
  */
-+ (NSArray *) humanKeyboardHandlerNames;
++ (NSArray<NSString *> *) humanKeyboardHandlerNames;
 
 /** Return the ACE keyboard handler command for a given ACEKeyboardHandler constant.
 

--- a/ACEView/Source/Utilities/Headers/ACEKeyboardHandlerNames.h
+++ b/ACEView/Source/Utilities/Headers/ACEKeyboardHandlerNames.h
@@ -1,5 +1,11 @@
 #import "ACEKeyboardHandlers.h"
 
+#if __has_feature(objc_generics)
+#define OF_NSSTRING <NSString *>
+#else
+#define OF_NSSTRING
+#endif
+
 /** Class providing methods to:
 
  - convert ACE keyboard handler names used internally to to their human-readable counterparts and vise-versa.
@@ -17,12 +23,12 @@
 
  @return Array of ACE keyboard handler names.
  */
-+ (NSArray<NSString *> *) keyboardHandlerCommands;
++ (NSArray OF_NSSTRING *) keyboardHandlerCommands;
 /** Return an array of human-readable ACE keyboard handler names.
 
  @return Array of human-readable ACE keyboard handler names.
  */
-+ (NSArray<NSString *> *) humanKeyboardHandlerNames;
++ (NSArray OF_NSSTRING *) humanKeyboardHandlerNames;
 
 /** Return the ACE keyboard handler command for a given ACEKeyboardHandler constant.
 

--- a/ACEView/Source/Utilities/Headers/ACEModeNames.h
+++ b/ACEView/Source/Utilities/Headers/ACEModeNames.h
@@ -25,12 +25,12 @@
 
  @return Array of ACE mode names.
  */
-+ (NSArray *) modeNames;
++ (NSArray<NSString *> *) modeNames;
 /** Return an array of human-readable ACE mode names.
 
  @return Array of human-readable ACE mode names.
  */
-+ (NSArray *) humanModeNames;
++ (NSArray<NSString *> *) humanModeNames;
 
 /** Return the ACE mode name for a given ACEmode constant.
 

--- a/ACEView/Source/Utilities/Headers/ACEModeNames.h
+++ b/ACEView/Source/Utilities/Headers/ACEModeNames.h
@@ -7,6 +7,12 @@
 //
 #import <ACEView/ACEModes.h>
 
+#if __has_feature(objc_generics)
+#define OF_NSSTRING <NSString *>
+#else
+#define OF_NSSTRING
+#endif
+
 /** Class providing methods to:
 
  - convert ACE mode names used internally to to their human-readable counterparts and vise-versa.
@@ -25,12 +31,12 @@
 
  @return Array of ACE mode names.
  */
-+ (NSArray<NSString *> *) modeNames;
++ (NSArray OF_NSSTRING *) modeNames;
 /** Return an array of human-readable ACE mode names.
 
  @return Array of human-readable ACE mode names.
  */
-+ (NSArray<NSString *> *) humanModeNames;
++ (NSArray OF_NSSTRING *) humanModeNames;
 
 /** Return the ACE mode name for a given ACEmode constant.
 

--- a/ACEView/Source/Utilities/Headers/ACEThemeNames.h
+++ b/ACEView/Source/Utilities/Headers/ACEThemeNames.h
@@ -7,6 +7,12 @@
 //
 #import <ACEView/ACEThemes.h>
 
+#if __has_feature(objc_generics)
+#define OF_NSSTRING <NSString *>
+#else
+#define OF_NSSTRING
+#endif
+
 /** Class providing methods to:
 
  - convert ACE theme names used internally to to their human-readable counterparts and vise-versa.
@@ -25,12 +31,12 @@
 
  @return Array of ACE theme names.
  */
-+ (NSArray<NSString *> *) themeNames;
++ (NSArray OF_NSSTRING *) themeNames;
 /** Return an array of human-readable ACE theme names.
 
  @return Array of human-readable ACE theme names.
  */
-+ (NSArray<NSString *> *) humanThemeNames;
++ (NSArray OF_NSSTRING *) humanThemeNames;
 
 /** Return the ACE theme name for a given ACETheme constant.
 

--- a/ACEView/Source/Utilities/Headers/ACEThemeNames.h
+++ b/ACEView/Source/Utilities/Headers/ACEThemeNames.h
@@ -25,12 +25,12 @@
 
  @return Array of ACE theme names.
  */
-+ (NSArray *) themeNames;
++ (NSArray<NSString *> *) themeNames;
 /** Return an array of human-readable ACE theme names.
 
  @return Array of human-readable ACE theme names.
  */
-+ (NSArray *) humanThemeNames;
++ (NSArray<NSString *> *) humanThemeNames;
 
 /** Return the ACE theme name for a given ACETheme constant.
 


### PR DESCRIPTION
Add the new Objective C lightweight generic declarations to some `NSArray *` returns to clarify that the `NSArray` returned contains exclusively `NSString` elements. This helps using `ACEView` from Swift, but requires using Xcode 7 to compile `ACEView` from now on, so I'm not sure whether this fits with your plans.
